### PR TITLE
[PRODSEC-1144] Fix auto_delete_engagements

### DIFF
--- a/dojo/cb_utils.py
+++ b/dojo/cb_utils.py
@@ -59,7 +59,7 @@ def auto_delete_engagements():
         all_duplicates=True,
         has_no_note=True
     ).exclude(
-        tagged_items__tag__name__contains=lock_tag
+        tags__name__contains=lock_tag
     )
 
     for engagement in engagements_to_delete:


### PR DESCRIPTION
Following the tagulous move as the tag libraries, the `tagged_items` was no longer recognized and was failing the command.