### PR TITLE
Skip dependency vulnerabilities from policy import for PRODSEC-1374

### DIFF
--- a/dojo/tools/anchore_enterprise/parser.py
+++ b/dojo/tools/anchore_enterprise/parser.py
@@ -46,6 +46,8 @@ class AnchoreEnterpriseParser:
                                     severity = map_gate_action_to_severity(row[6])
                                     policyid = row[8]
                                     policyname = policy_name(evaluation['detail']['policy']['policies'], policyid)
+                                    if policy_name == 'Software Checks':
+                                        continue
                                     gate = row[3]
                                     triggerid = row[2]
                                     cve = extract_cve(triggerid)


### PR DESCRIPTION
Skipping import of policy failures related to dependency vulnerabilities, as those are already consumed through the Anchore vulnerability results.